### PR TITLE
Decode Avro Enum Symbols as bytes

### DIFF
--- a/src/avro_binary_decoder.erl
+++ b/src/avro_binary_decoder.erl
@@ -95,7 +95,7 @@ dec(Bin, T, _Lkup, Hook) when ?AVRO_IS_ENUM_TYPE(T) ->
   Hook(T, Index, Tail,
        fun(B) ->
          Symbol = avro_enum:get_symbol_from_index(T, Index),
-         {Symbol, B}
+         {erlang:list_to_binary(Symbol), B}
        end);
 dec(Bin, T, Lkup, Hook) when ?AVRO_IS_ARRAY_TYPE(T) ->
   ItemsType = avro_array:get_items_type(T),


### PR DESCRIPTION
Previously we patched erlavro to return strings as bytes, so that Elixir can see them as binaries => utf8 strings, rather than charlists (Erlang strings) see commit https://github.com/avvo/erlavro/commit/fb7c7f0b2784468edeea0961984247242097aee5

https://github.com/avvo/grants/pull/19 deals with Enum Symbols - and since Avro Enum Symbols are strings - we can similarly return binary instead of charlists